### PR TITLE
Pin Helm version to v3.19.2

### DIFF
--- a/.github/workflows/k8s-deploy.yml
+++ b/.github/workflows/k8s-deploy.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install helm
         uses: azure/setup-helm@v3
         with:
-          version: "latest"
+          version: "v3.19.2"
           token: ${{ secrets.GITHUB_TOKEN }}
         id: install
 


### PR DESCRIPTION
Pin Helm to v3.19.2 for consistent deployments across all services.