### PR TITLE
Fix helm namespace - deploy to default namespace

### DIFF
--- a/.github/workflows/k8s-deploy.yml
+++ b/.github/workflows/k8s-deploy.yml
@@ -66,11 +66,12 @@ jobs:
 
       - name: Clear pending deployments
         run: |
-          kubectl delete secret -l 'status in (pending-install, pending-upgrade, pending-rollback),name=assets-service-production'
+          kubectl delete secret -n default -l 'status in (pending-install, pending-upgrade, pending-rollback),name=assets-service-production'
 
       - name: Show manifest diff since previous release
         run: |
           helm diff upgrade \
+          --namespace default \
           --allow-unreleased \
           --color=true \
           --values chart/values.yaml \
@@ -80,6 +81,7 @@ jobs:
       - name: Deploy service to production cluster
         run: |
           helm upgrade \
+            --namespace default \
             --install \
             --atomic \
             --wait --timeout 10m \


### PR DESCRIPTION
## Summary
- Add `--namespace default` to helm upgrade and helm diff upgrade commands
- Add `-n default` to kubectl delete secret command

## Why
The self-hosted runner runs in the `github-runner` namespace, so helm uses that as the default namespace. This caused helm to think releases didn't exist (it was looking in `github-runner` but releases are in `default`).

## Test plan
- Merge and verify the next deployment succeeds